### PR TITLE
Manipulate composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/.idea
+/vendor
+/composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,32 @@
+{
+    "name": "efabrica/rector-composer",
+    "type": "rector-extension",
+    "license": "MIT",
+    "description": "Allows Rector to make changes in composer.json",
+    "require": {
+        "php": "> 8.1",
+        "rector/rector": "^0.14.5",
+        "symplify/composer-json-manipulator": "^11.1",
+        "composer/semver": "^3.3"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.5"
+    },
+    "autoload": {
+        "psr-4": {
+            "RectorComposer\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "RectorComposer\\Tests\\": "tests"
+        }
+    },
+    "extra": {
+        "rector": {
+            "includes": [
+                "config/config.php"
+            ]
+        }
+    }
+}

--- a/config/config.php
+++ b/config/config.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void
+{
+
+    $services = $rectorConfig->services();
+
+    $services->defaults()
+        ->public()
+        ->autowire()
+        ->autoconfigure();
+
+    $services->load('RectorComposer\\', __DIR__ . '/../src')
+        ->exclude([__DIR__ . '/../src/Contract', __DIR__ . '/../src/Rector', __DIR__ . '/../src/ValueObject']);
+};

--- a/config/config.php
+++ b/config/config.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Composer\Semver\VersionParser;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void
@@ -16,4 +17,6 @@ return static function (RectorConfig $rectorConfig): void
 
     $services->load('RectorComposer\\', __DIR__ . '/../src')
         ->exclude([__DIR__ . '/../src/Contract', __DIR__ . '/../src/Rector', __DIR__ . '/../src/ValueObject']);
+
+    $services->set(VersionParser::class);
 };

--- a/config/sets/nette-24.php
+++ b/config/sets/nette-24.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Transform\Rector\Class_\ParentClassToTraitsRector;
+use Rector\Transform\ValueObject\ParentClassToTraits;
+
+// @see https://doc.nette.org/en/2.4/migration-2-4#toc-nette-smartobject
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(ParentClassToTraitsRector::class, [
+        new ParentClassToTraits('Nette\Object', ['Nette\SmartObject']),
+    ]);
+};

--- a/config/sets/nette-30.php
+++ b/config/sets/nette-30.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Arguments\Rector\ClassMethod\ReplaceArgumentDefaultValueRector;
+use Rector\Arguments\ValueObject\ReplaceArgumentDefaultValue;
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\StaticCall\RemoveParentCallWithoutParentRector;
+use Rector\Renaming\Rector\ClassConstFetch\RenameClassConstFetchRector;
+use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+use Rector\Renaming\ValueObject\MethodCallRename;
+use Rector\Renaming\ValueObject\RenameClassConstFetch;
+use Rector\Transform\Rector\StaticCall\StaticCallToMethodCallRector;
+use Rector\Transform\ValueObject\StaticCallToMethodCall;
+use RectorNette\Rector\ClassMethod\RemoveParentAndNameFromComponentConstructorRector;
+use RectorNette\Rector\MethodCall\ConvertAddUploadWithThirdArgumentTrueToAddMultiUploadRector;
+use RectorNette\Rector\MethodCall\MagicHtmlCallToAppendAttributeRector;
+use RectorNette\Rector\MethodCall\MergeDefaultsInGetConfigCompilerExtensionRector;
+use RectorNette\Rector\MethodCall\RequestGetCookieDefaultArgumentToCoalesceRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->sets([
+        __DIR__ . '/nette-30/nette-30-composer.php',
+        __DIR__ . '/nette-30/nette-30-dependency-injection.php',
+        __DIR__ . '/nette-30/nette-30-return-types.php',
+        __DIR__ . '/nette-30/nette-30-param-types.php',
+    ]);
+
+    $rectorConfig->rule(MergeDefaultsInGetConfigCompilerExtensionRector::class);
+    // Control class has remove __construct(), e.g. https://github.com/Pixidos/GPWebPay/pull/16/files#diff-fdc8251950f85c5467c63c249df05786
+    $rectorConfig->rule(RemoveParentCallWithoutParentRector::class);
+
+    $rectorConfig->ruleWithConfiguration(StaticCallToMethodCallRector::class, [
+        new StaticCallToMethodCall('Nette\Security\Passwords', 'hash', 'Nette\Security\Passwords', 'hash'),
+        new StaticCallToMethodCall('Nette\Security\Passwords', 'verify', 'Nette\Security\Passwords', 'verify'),
+        new StaticCallToMethodCall(
+            'Nette\Security\Passwords',
+            'needsRehash',
+            'Nette\Security\Passwords',
+            'needsRehash'
+        ),
+    ]);
+
+    // https://github.com/contributte/event-dispatcher-extra/tree/v0.4.3 and higher
+    $rectorConfig->ruleWithConfiguration(RenameClassConstFetchRector::class, [
+        new RenameClassConstFetch('Contributte\Events\Extra\Event\Security\LoggedInEvent', 'NAME', 'class'),
+        new RenameClassConstFetch('Contributte\Events\Extra\Event\Security\LoggedOutEvent', 'NAME', 'class'),
+        new RenameClassConstFetch('Contributte\Events\Extra\Event\Application\ShutdownEvent', 'NAME', 'class'),
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
+        # nextras/forms was split into 2 packages
+        'Nextras\FormComponents\Controls\DatePicker' => 'Nextras\FormComponents\Controls\DateControl',
+        # @see https://github.com/nette/di/commit/a0d361192f8ac35f1d9f82aab7eb351e4be395ea
+        'Nette\DI\ServiceDefinition' => 'Nette\DI\Definitions\ServiceDefinition',
+        'Nette\DI\Statement' => 'Nette\DI\Definitions\Statement',
+        'WebChemistry\Forms\Controls\Multiplier' => 'Contributte\FormMultiplier\Multiplier',
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(ReplaceArgumentDefaultValueRector::class, [
+        // json 2nd argument is now `int` typed
+        new ReplaceArgumentDefaultValue('Nette\Utils\Json', 'decode', 1, true, 'Nette\Utils\Json::FORCE_ARRAY'),
+        // @see https://github.com/nette/forms/commit/574b97f9d5e7a902a224e57d7d584e7afc9fefec
+        new ReplaceArgumentDefaultValue('Nette\Forms\Form', 'decode', 0, true, 'array'),
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(RenameMethodRector::class, [
+        // see https://github.com/nette/forms/commit/b99385aa9d24d729a18f6397a414ea88eab6895a
+        new MethodCallRename('Nette\Forms\Controls\BaseControl', 'setType', 'setHtmlType'),
+        new MethodCallRename('Nette\Forms\Controls\BaseControl', 'setAttribute', 'setHtmlAttribute'),
+        new MethodCallRename(
+            'Nette\DI\Definitions\ServiceDefinition',
+            # see https://github.com/nette/di/commit/1705a5db431423fc610a6f339f88dead1b5dc4fb
+            'setClass',
+            'setType'
+        ),
+        new MethodCallRename('Nette\DI\Definitions\ServiceDefinition', 'getClass', 'getType'),
+        new MethodCallRename('Nette\DI\Definitions\Definition', 'isAutowired', 'getAutowired'),
+    ]);
+
+    $rectorConfig->rule(MagicHtmlCallToAppendAttributeRector::class);
+    $rectorConfig->rule(RequestGetCookieDefaultArgumentToCoalesceRector::class);
+    $rectorConfig->rule(RemoveParentAndNameFromComponentConstructorRector::class);
+    $rectorConfig->rule(ConvertAddUploadWithThirdArgumentTrueToAddMultiUploadRector::class);
+};

--- a/config/sets/nette-30/nette-30-composer.php
+++ b/config/sets/nette-30/nette-30-composer.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Composer\Rector\ChangePackageVersionComposerRector;
+use Rector\Composer\Rector\RemovePackageComposerRector;
+use Rector\Composer\Rector\ReplacePackageAndVersionComposerRector;
+use Rector\Composer\ValueObject\PackageAndVersion;
+use Rector\Composer\ValueObject\ReplacePackageAndVersion;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(ChangePackageVersionComposerRector::class, [
+        new PackageAndVersion('nette/nette', '^3.0'),
+        // https://github.com/nette/nette/blob/v2.4.0/composer.json vs https://github.com/nette/nette/blob/v3.0.0/composer.json
+        // older versions have security issues
+        new PackageAndVersion('nette/application', '^3.0.6'),
+        new PackageAndVersion('nette/bootstrap', '^3.0'),
+        new PackageAndVersion('nette/caching', '^3.0'),
+        new PackageAndVersion('nette/component-model', '^3.0'),
+        new PackageAndVersion('nette/database', '^3.0'),
+        new PackageAndVersion('nette/di', '^3.0'),
+        new PackageAndVersion('nette/finder', '^2.5'),
+        new PackageAndVersion('nette/forms', '^3.0'),
+        new PackageAndVersion('nette/http', '^3.0'),
+        new PackageAndVersion('nette/mail', '^3.0'),
+        new PackageAndVersion('nette/neon', '^3.0'),
+        new PackageAndVersion('nette/php-generator', '^3.0'),
+        new PackageAndVersion('nette/robot-loader', '^3.0'),
+        new PackageAndVersion('nette/safe-stream', '^2.4'),
+        new PackageAndVersion('nette/security', '^3.0'),
+        new PackageAndVersion('nette/tokenizer', '^3.0'),
+        new PackageAndVersion('nette/utils', '^3.0'),
+        new PackageAndVersion('latte/latte', '^2.5'),
+        new PackageAndVersion('tracy/tracy', '^2.6'),
+
+        // contributte packages
+        new PackageAndVersion('contributte/event-dispatcher-extra', '^0.8'),
+        new PackageAndVersion('contributte/forms-multiplier', '3.1.x-dev'),
+        // other packages
+        new PackageAndVersion('radekdostal/nette-datetimepicker', '^3.0'),
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(RemovePackageComposerRector::class, [
+        'nette/deprecated', 'nette/reflection',
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(ReplacePackageAndVersionComposerRector::class, [
+        // webchemistry to contributte
+        new ReplacePackageAndVersion('webchemistry/forms-multiplier', 'contributte/forms-multiplier', '3.1.x-dev'),
+    ]);
+};

--- a/config/sets/nette-30/nette-30-dependency-injection.php
+++ b/config/sets/nette-30/nette-30-dependency-injection.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorNette\Rector\MethodCall\BuilderExpandToHelperExpandRector;
+use RectorNette\Rector\MethodCall\SetClassWithArgumentToSetFactoryRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(SetClassWithArgumentToSetFactoryRector::class);
+    $rectorConfig->rule(BuilderExpandToHelperExpandRector::class);
+};

--- a/config/sets/nette-30/nette-30-param-types.php
+++ b/config/sets/nette-30/nette-30-param-types.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPStan\Type\BooleanType;
+use PHPStan\Type\CallableType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\IterableType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\NullType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\UnionType;
+use Rector\Config\RectorConfig;
+use Rector\Core\ValueObject\MethodName;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddParamTypeDeclarationRector;
+use Rector\TypeDeclaration\ValueObject\AddParamTypeDeclaration;
+use RectorNette\Rector\ClassMethod\TranslateClassMethodToVariadicsRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(TranslateClassMethodToVariadicsRector::class);
+
+    # scalar type hints, see https://github.com/nette/component-model/commit/f69df2ca224cad7b07f1c8835679393263ea6771
+    # scalar param types https://github.com/nette/security/commit/84024f612fb3f55f5d6e3e3e28eef1ad0388fa56
+
+    $iterableType = new IterableType(new MixedType(), new MixedType());
+
+    $rectorConfig->ruleWithConfiguration(AddParamTypeDeclarationRector::class, [
+        new AddParamTypeDeclaration(
+            'Nette\ComponentModel\Component',
+            'lookup',
+            0,
+            new UnionType([new StringType(), new NullType()])
+        ),
+        new AddParamTypeDeclaration('Nette\ComponentModel\Component', 'lookup', 1, new BooleanType()),
+        new AddParamTypeDeclaration('Nette\ComponentModel\Component', 'lookupPath', 0, new StringType()),
+        new AddParamTypeDeclaration('Nette\ComponentModel\Component', 'lookupPath', 1, new BooleanType()),
+        new AddParamTypeDeclaration('Nette\ComponentModel\Component', 'monitor', 0, new StringType()),
+        new AddParamTypeDeclaration('Nette\ComponentModel\Component', 'unmonitor', 0, new StringType()),
+        new AddParamTypeDeclaration(
+            'Nette\ComponentModel\Component',
+            'attached',
+            0,
+            new ObjectType('Nette\ComponentModel\IComponent')
+        ),
+        new AddParamTypeDeclaration(
+            'Nette\ComponentModel\Component',
+            'detached',
+            0,
+            new ObjectType('Nette\ComponentModel\IComponent')
+        ),
+        new AddParamTypeDeclaration('Nette\ComponentModel\Component', 'link', 0, new StringType()),
+        new AddParamTypeDeclaration('Nette\ComponentModel\Container', 'getComponent', 1, new BooleanType()),
+        new AddParamTypeDeclaration('Nette\ComponentModel\Container', 'createComponent', 0, new StringType()),
+        new AddParamTypeDeclaration(
+            'Nette\ComponentModel\IComponent',
+            'setParent',
+            0,
+            new UnionType([new ObjectType('Nette\ComponentModel\IContainer'), new NullType()])
+        ),
+        new AddParamTypeDeclaration('Nette\ComponentModel\IComponent', 'setParent', 1, new StringType()),
+        new AddParamTypeDeclaration('Nette\ComponentModel\IContainer', 'getComponents', 0, new BooleanType()),
+        new AddParamTypeDeclaration('Nette\Forms\Container', 'addSelect', 0, new StringType()),
+        new AddParamTypeDeclaration('Nette\Forms\Container', 'addSelect', 3, new IntegerType()),
+        new AddParamTypeDeclaration('Nette\Forms\Container', 'addMultiSelect', 0, new StringType()),
+        new AddParamTypeDeclaration('Nette\Forms\Container', 'addMultiSelect', 3, new IntegerType()),
+        new AddParamTypeDeclaration('Nette\Forms\Rendering\DefaultFormRenderer', 'render', 1, new StringType()),
+        new AddParamTypeDeclaration(
+            'RadekDostal\NetteComponents\DateTimePicker\DateTimePicker',
+            'register',
+            0,
+            new StringType()
+        ),
+        new AddParamTypeDeclaration(
+            'Nette\Bridges\SecurityDI\SecurityExtension',
+            MethodName::CONSTRUCT,
+            0,
+            new BooleanType()
+        ),
+        new AddParamTypeDeclaration('Nette\Security\IUserStorage', 'setAuthenticated', 0, new BooleanType()),
+        new AddParamTypeDeclaration(
+            'Nette\Security\IUserStorage',
+            'setIdentity',
+            0,
+            new UnionType([new ObjectType('Nette\Security\IIdentity'), new NullType()])
+        ),
+        new AddParamTypeDeclaration('Nette\Security\IUserStorage', 'setExpiration', 1, new IntegerType()),
+        new AddParamTypeDeclaration('Nette\Security\Identity', MethodName::CONSTRUCT, 2, $iterableType),
+        new AddParamTypeDeclaration('Nette\Security\Identity', '__set', 0, new StringType()),
+        new AddParamTypeDeclaration('Nette\Security\Identity', '&__get', 0, new StringType()),
+        new AddParamTypeDeclaration('Nette\Security\Identity', '__isset', 0, new StringType()),
+        new AddParamTypeDeclaration('Nette\Security\Passwords', 'hash', 0, new StringType()),
+        new AddParamTypeDeclaration('Nette\Security\Passwords', 'verify', 0, new StringType()),
+        new AddParamTypeDeclaration('Nette\Security\Passwords', 'verify', 1, new StringType()),
+        new AddParamTypeDeclaration('Nette\Security\Passwords', 'needsRehash', 0, new StringType()),
+        new AddParamTypeDeclaration('Nette\Security\Permission', 'addRole', 0, new StringType()),
+        new AddParamTypeDeclaration('Nette\Security\Permission', 'hasRole', 0, new StringType()),
+        new AddParamTypeDeclaration('Nette\Security\Permission', 'getRoleParents', 0, new StringType()),
+        new AddParamTypeDeclaration('Nette\Security\Permission', 'removeRole', 0, new StringType()),
+        new AddParamTypeDeclaration('Nette\Security\Permission', 'addResource', 0, new StringType()),
+        new AddParamTypeDeclaration('Nette\Security\Permission', 'addResource', 1, new StringType()),
+        new AddParamTypeDeclaration('Nette\Security\Permission', 'hasResource', 0, new StringType()),
+        new AddParamTypeDeclaration('Nette\Security\Permission', 'resourceInheritsFrom', 0, new StringType()),
+        new AddParamTypeDeclaration('Nette\Security\Permission', 'resourceInheritsFrom', 1, new StringType()),
+        new AddParamTypeDeclaration('Nette\Security\Permission', 'resourceInheritsFrom', 2, new BooleanType()),
+        new AddParamTypeDeclaration('Nette\Security\Permission', 'removeResource', 0, new StringType()),
+        new AddParamTypeDeclaration('Nette\Security\Permission', 'allow', 3, new CallableType()),
+        new AddParamTypeDeclaration('Nette\Security\Permission', 'deny', 3, new CallableType()),
+        new AddParamTypeDeclaration('Nette\Security\Permission', 'setRule', 0, new BooleanType()),
+        new AddParamTypeDeclaration('Nette\Security\Permission', 'setRule', 1, new BooleanType()),
+        new AddParamTypeDeclaration('Nette\Security\Permission', 'setRule', 5, new CallableType()),
+        new AddParamTypeDeclaration('Nette\Security\User', 'logout', 0, new BooleanType()),
+        new AddParamTypeDeclaration('Nette\Security\User', 'getAuthenticator', 0, new BooleanType()),
+        new AddParamTypeDeclaration('Nette\Security\User', 'isInRole', 0, new StringType()),
+        new AddParamTypeDeclaration('Nette\Security\User', 'getAuthorizator', 0, new BooleanType()),
+        new AddParamTypeDeclaration('Nette\Security\User', 'getAuthorizator', 1, new StringType()),
+    ]);
+};

--- a/config/sets/nette-30/nette-30-return-types.php
+++ b/config/sets/nette-30/nette-30-return-types.php
@@ -1,0 +1,540 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\BooleanType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\NullType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\UnionType;
+use PHPStan\Type\VoidType;
+use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector;
+use Rector\TypeDeclaration\ValueObject\AddReturnTypeDeclaration;
+
+return static function (RectorConfig $rectorConfig): void {
+    # scalar type hints, see https://github.com/nette/security/commit/84024f612fb3f55f5d6e3e3e28eef1ad0388fa56
+    $arrayType = new ArrayType(new MixedType(), new MixedType());
+
+    $rectorConfig->ruleWithConfiguration(AddReturnTypeDeclarationRector::class, [
+        new AddReturnTypeDeclaration('Nette\Mail\Mailer', 'send', new VoidType()),
+        new AddReturnTypeDeclaration(
+            'Nette\Forms\Rendering\DefaultFormRenderer',
+            'renderControl',
+            new ObjectType('Nette\Utils\Html')
+        ),
+        new AddReturnTypeDeclaration(
+            'Nette\Forms\Container',
+            'addContainer',
+            new ObjectType('Nette\Forms\Container')
+        ),
+        new AddReturnTypeDeclaration(
+            'Nette\Forms\Container',
+            'addSelect',
+            new ObjectType('Nette\Forms\Controls\SelectBox')
+        ),
+        new AddReturnTypeDeclaration(
+            'Nette\Forms\Container',
+            'addMultiSelect',
+            new ObjectType('Nette\Forms\Controls\MultiSelectBox')
+        ),
+        new AddReturnTypeDeclaration('Nette\Forms\IFormRenderer', 'render', new StringType()),
+        new AddReturnTypeDeclaration(
+            'Nette\Forms\Controls\TextBase',
+            'getControl',
+            new ObjectType('Nette\Utils\Html')
+        ),
+        new AddReturnTypeDeclaration(
+            'RadekDostal\NetteComponents\DateTimePicker\DateTimePicker',
+            'register',
+            new VoidType()
+        ),
+        new AddReturnTypeDeclaration('Nette\Caching\Cache', 'generateKey', new StringType()),
+        new AddReturnTypeDeclaration('Nette\Localization\ITranslator', 'translate', new StringType()),
+        new AddReturnTypeDeclaration('Nette\Security\IResource', 'getResourceId', new StringType()),
+        new AddReturnTypeDeclaration(
+            'Nette\Security\IAuthenticator',
+            'authenticate',
+            new ObjectType('Nette\Security\IIdentity')
+        ),
+        new AddReturnTypeDeclaration('Nette\Security\IAuthorizator', 'isAllowed', new BooleanType()),
+        new AddReturnTypeDeclaration('Nette\Security\Identity', 'getData', $arrayType),
+        new AddReturnTypeDeclaration('Nette\Security\IIdentity', 'getRoles', $arrayType),
+        new AddReturnTypeDeclaration(
+            'Nette\Security\User',
+            'getStorage',
+            new ObjectType('Nette\Security\IUserStorage')
+        ),
+        new AddReturnTypeDeclaration('Nette\Security\User', 'login', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Security\User', 'logout', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Security\User', 'isLoggedIn', new BooleanType()),
+
+        new AddReturnTypeDeclaration(
+            'Nette\Security\User',
+            'getIdentity',
+            new UnionType([new ObjectType('Nette\Security\IIdentity'), new NullType()])
+        ),
+        new AddReturnTypeDeclaration(
+            'Nette\Security\User',
+            'getAuthenticator',
+            new UnionType([new ObjectType('Nette\Security\IAuthenticator'), new NullType()])
+        ),
+        new AddReturnTypeDeclaration(
+            'Nette\Security\User',
+            'getAuthorizator',
+            new UnionType([new ObjectType('Nette\Security\IAuthorizator'), new NullType()])
+        ),
+        new AddReturnTypeDeclaration(
+            'Nette\Security\User',
+            'getLogoutReason',
+            new UnionType([new IntegerType(), new NullType()])
+        ),
+        new AddReturnTypeDeclaration('Nette\Security\User', 'getRoles', $arrayType),
+        new AddReturnTypeDeclaration('Nette\Security\User', 'isInRole', new BooleanType()),
+        new AddReturnTypeDeclaration('Nette\Security\User', 'isAllowed', new BooleanType()),
+        new AddReturnTypeDeclaration('Nette\Security\IUserStorage', 'isAuthenticated', new BooleanType()),
+        new AddReturnTypeDeclaration(
+            'Nette\Security\IUserStorage',
+            'getIdentity',
+            new UnionType([new ObjectType('Nette\Security\IIdentity'), new NullType()])
+        ),
+        new AddReturnTypeDeclaration(
+            'Nette\Security\IUserStorage',
+            'getLogoutReason',
+            new UnionType([new IntegerType(), new NullType()])
+        ),
+        new AddReturnTypeDeclaration(
+            'Nette\ComponentModel\Component',
+            'lookup',
+            new ObjectType('Nette\ComponentModel\IComponent')
+        ),
+        new AddReturnTypeDeclaration('Nette\ComponentModel\Component', 'lookupPath', new UnionType([
+            new StringType(),
+            new NullType(),
+        ])),
+        new AddReturnTypeDeclaration('Nette\ComponentModel\Component', 'monitor', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\ComponentModel\Component', 'unmonitor', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\ComponentModel\Component', 'attached', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\ComponentModel\Component', 'detached', new VoidType()),
+        new AddReturnTypeDeclaration(
+            'Nette\ComponentModel\Component',
+            'getName',
+            new UnionType([new StringType(), new NullType()])
+        ),
+        new AddReturnTypeDeclaration(
+            'Nette\ComponentModel\IComponent',
+            'getName',
+            new UnionType([new StringType(), new NullType()])
+        ),
+        new AddReturnTypeDeclaration(
+            'Nette\ComponentModel\IComponent',
+            'getParent',
+            new UnionType([new ObjectType('Nette\ComponentModel\IContainer'), new NullType()])
+        ),
+        new AddReturnTypeDeclaration('Nette\ComponentModel\Container', 'removeComponent', new VoidType()),
+        new AddReturnTypeDeclaration(
+            'Nette\ComponentModel\Container',
+            'getComponent',
+            new UnionType([new ObjectType('Nette\ComponentModel\IComponent'), new NullType()])
+        ),
+        new AddReturnTypeDeclaration(
+            'Nette\ComponentModel\Container',
+            'createComponent',
+            new UnionType([new ObjectType('Nette\ComponentModel\IComponent'), new NullType()])
+        ),
+        new AddReturnTypeDeclaration('Nette\ComponentModel\Container', 'getComponents', new ObjectType('Iterator')),
+        new AddReturnTypeDeclaration('Nette\ComponentModel\Container', 'validateChildComponent', new VoidType()),
+        new AddReturnTypeDeclaration(
+            'Nette\ComponentModel\Container',
+            '_isCloning',
+            new UnionType([new ObjectType('Nette\ComponentModel\IComponent'), new NullType()])
+        ),
+        new AddReturnTypeDeclaration('Nette\ComponentModel\IContainer', 'removeComponent', new VoidType()),
+        new AddReturnTypeDeclaration(
+            'Nette\ComponentModel\IContainer',
+            'getComponent',
+            new UnionType([new ObjectType('Nette\ComponentModel\IContainer'), new NullType()])
+        ),
+        new AddReturnTypeDeclaration('Nette\ComponentModel\IContainer', 'getComponents', new ObjectType(
+            'Iterator'
+        )),
+        new AddReturnTypeDeclaration('Nette\Application\Application', 'run', new VoidType()),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\Application',
+            'createInitialRequest',
+            new ObjectType('Nette\Application\Request')
+        ),
+        new AddReturnTypeDeclaration('Nette\Application\Application', 'processRequest', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Application\Application', 'processException', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Application\Application', 'getRequests', $arrayType),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\Application',
+            'getPresenter',
+            new UnionType([new ObjectType('Nette\Application\IPresenter'), new NullType()])
+        ),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\Application',
+            'getRouter',
+            new UnionType([new ObjectType('Nette\Application\IRouter'), new NullType()])
+        ),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\Application',
+            'getPresenterFactory',
+            new UnionType([new ObjectType('Nette\Application\IPresenterFactory'), new NullType()])
+        ),
+        new AddReturnTypeDeclaration('Nette\Application\Helpers', 'splitName', $arrayType),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\IPresenter',
+            'run',
+            new ObjectType('Nette\Application\IResponse')
+        ),
+        new AddReturnTypeDeclaration('Nette\Application\IPresenterFactory', 'getPresenterClass', new StringType()),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\IPresenterFactory',
+            'createPresenter',
+            new ObjectType('Nette\Application\IPresenter')
+        ),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\PresenterFactory',
+            'formatPresenterClass',
+            new StringType()
+        ),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\PresenterFactory',
+            'unformatPresenterClass',
+            new UnionType([new StringType(), new NullType()])
+        ),
+        new AddReturnTypeDeclaration('Nette\Application\IResponse', 'send', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Application\Responses\FileResponse', 'getFile', new StringType()),
+        new AddReturnTypeDeclaration('Nette\Application\Responses\FileResponse', 'getName', new StringType()),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\Responses\FileResponse',
+            'getContentType',
+            new StringType()
+        ),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\Responses\ForwardResponse',
+            'getRequest',
+            new ObjectType('Nette\Application\Request')
+        ),
+        new AddReturnTypeDeclaration('Nette\Application\Request', 'getPresenterName', new StringType()),
+        new AddReturnTypeDeclaration('Nette\Application\Request', 'getParameters', $arrayType),
+        new AddReturnTypeDeclaration('Nette\Application\Request', 'getFiles', $arrayType),
+        new AddReturnTypeDeclaration('Nette\Application\Request', 'getMethod', new UnionType([
+            new StringType(),
+            new NullType(),
+        ])),
+        new AddReturnTypeDeclaration('Nette\Application\Request', 'isMethod', new BooleanType()),
+        new AddReturnTypeDeclaration('Nette\Application\Request', 'hasFlag', new BooleanType()),
+        new AddReturnTypeDeclaration('Nette\Application\RedirectResponse', 'getUrl', new StringType()),
+        new AddReturnTypeDeclaration('Nette\Application\RedirectResponse', 'getCode', new IntegerType()),
+        new AddReturnTypeDeclaration('Nette\Application\JsonResponse', 'getContentType', new StringType()),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\IRouter',
+            'match',
+            new UnionType([new ObjectType('Nette\Application\Request'), new NullType()])
+        ),
+        new AddReturnTypeDeclaration('Nette\Application\IRouter', 'constructUrl', new UnionType([
+            new StringType(),
+            new NullType(),
+        ])),
+        new AddReturnTypeDeclaration('Nette\Application\Routers\Route', 'getMask', new StringType()),
+        new AddReturnTypeDeclaration('Nette\Application\Routers\Route', 'getDefaults', $arrayType),
+        new AddReturnTypeDeclaration('Nette\Application\Routers\Route', 'getFlags', new IntegerType()),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\Routers\Route',
+            'getTargetPresenters',
+            new UnionType([$arrayType, new NullType()])
+        ),
+        new AddReturnTypeDeclaration('Nette\Application\Routers\RouteList', 'warmupCache', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Application\Routers\RouteList', 'offsetSet', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Application\Routers\RouteList', 'getModule', new UnionType([
+            new StringType(),
+            new NullType(),
+        ])),
+        new AddReturnTypeDeclaration('Nette\Application\Routers\CliRouter', 'getDefaults', $arrayType),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\UI\Component',
+            'getPresenter',
+            new UnionType([new ObjectType('Nette\Application\UI\Presenter'), new NullType()])
+        ),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Component', 'getUniqueId', new StringType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Component', 'tryCall', new BooleanType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Component', 'checkRequirements', new VoidType()),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\UI\Component',
+            'getReflection',
+            new ObjectType('Nette\Application\UI\ComponentReflection')
+        ),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Component', 'loadState', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Component', 'saveState', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Component', 'getParameters', $arrayType),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Component', 'getParameterId', new StringType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Component', 'getPersistentParams', $arrayType),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Component', 'signalReceived', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Component', 'formatSignalMethod', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Component', 'link', new StringType()),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\UI\Component',
+            'lazyLink',
+            new ObjectType('Nette\Application\UI\Link')
+        ),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Component', 'isLinkCurrent', new BooleanType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Component', 'redirect', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Component', 'redirectPermanent', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Component', 'offsetSet', new VoidType()),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\UI\Component',
+            'offsetGet',
+            new ObjectType('Nette\ComponentModel\IComponent')
+        ),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Component', 'offsetExists', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Component', 'offsetUnset', new VoidType()),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\UI\Presenter',
+            'getRequest',
+            new ObjectType('Nette\Application\Request')
+        ),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\UI\Presenter',
+            'getPresenter',
+            new ObjectType('Nette\Application\UI\Presenter')
+        ),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Presenter', 'getUniqueId', new StringType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Presenter', 'checkRequirements', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Presenter', 'processSignal', new VoidType()),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\UI\Presenter',
+            'getSignal',
+            new UnionType([$arrayType, new NullType()])
+        ),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Presenter', 'isSignalReceiver', new BooleanType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Presenter', 'getAction', new StringType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Presenter', 'changeAction', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Presenter', 'getView', new StringType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Presenter', 'sendTemplate', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Presenter', 'findLayoutTemplateFile', new UnionType([
+            new StringType(),
+            new NullType(),
+        ])),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Presenter', 'formatLayoutTemplateFiles', $arrayType),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Presenter', 'formatTemplateFiles', $arrayType),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Presenter', 'formatActionMethod', new StringType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Presenter', 'formatRenderMethod', new StringType()),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\UI\Presenter',
+            'createTemplate',
+            new ObjectType('Nette\Application\UI\ITemplate')
+        ),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Presenter', 'getPayload', new ObjectType('stdClass')),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Presenter', 'isAjax', new BooleanType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Presenter', 'sendPayload', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Presenter', 'sendJson', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Presenter', 'sendResponse', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Presenter', 'terminate', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Presenter', 'forward', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Presenter', 'redirectUrl', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Presenter', 'error', new VoidType()),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\UI\Presenter',
+            'getLastCreatedRequest',
+            new UnionType([new ObjectType('Nette\Application\Request'), new NullType()])
+        ),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\UI\Presenter',
+            'getLastCreatedRequestFlag',
+            new BooleanType()
+        ),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Presenter', 'canonicalize', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Presenter', 'lastModified', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Presenter', 'createRequest', new UnionType([
+            new StringType(),
+            new NullType(),
+        ])),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Presenter', 'argsToParams', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Presenter', 'handleInvalidLink', new StringType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Presenter', 'storeRequest', new StringType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Presenter', 'restoreRequest', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Presenter', 'getPersistentComponents', $arrayType),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Presenter', 'getGlobalState', $arrayType),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Presenter', 'saveGlobalState', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Presenter', 'initGlobalParameters', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Presenter', 'popGlobalParameters', $arrayType),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Presenter', 'getFlashKey', new UnionType([
+            new StringType(),
+            new NullType(),
+        ])),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Presenter', 'hasFlashSession', new BooleanType()),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\UI\Presenter',
+            'getFlashSession',
+            new ObjectType('Nette\Http\SessionSection')
+        ),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\UI\Presenter',
+            'getContext',
+            new ObjectType('Nette\DI\Container')
+        ),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\UI\Presenter',
+            'getHttpRequest',
+            new ObjectType('Nette\Http\IRequest')
+        ),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\UI\Presenter',
+            'getHttpResponse',
+            new ObjectType('Nette\Http\IResponse')
+        ),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\UI\Presenter',
+            'getUser',
+            new ObjectType('Nette\Security\User')
+        ),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\UI\Presenter',
+            'getTemplateFactory',
+            new ObjectType('Nette\Application\UI\ITemplateFactory')
+        ),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\Exception\BadRequestException',
+            'getHttpCode',
+            new IntegerType()
+        ),
+        new AddReturnTypeDeclaration('Nette\Bridges\ApplicationDI\LatteExtension', 'addMacro', new VoidType()),
+        new AddReturnTypeDeclaration(
+            'Nette\Bridges\ApplicationDI\PresenterFactoryCallback',
+            '__invoke',
+            new ObjectType('Nette\Application\IPresenter')
+        ),
+        new AddReturnTypeDeclaration(
+            'Nette\Bridges\ApplicationLatte\ILatteFactory',
+            'create',
+            new ObjectType('Latte\Engine')
+        ),
+        new AddReturnTypeDeclaration(
+            'Nette\Bridges\ApplicationLatte\Template',
+            'getLatte',
+            new ObjectType('Latte\Engine')
+        ),
+        new AddReturnTypeDeclaration('Nette\Bridges\ApplicationLatte\Template', 'render', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Bridges\ApplicationLatte\Template', '__toString', new StringType()),
+        new AddReturnTypeDeclaration('Nette\Bridges\ApplicationLatte\Template', 'getFile', new UnionType([
+            new StringType(),
+            new NullType(),
+        ])),
+        new AddReturnTypeDeclaration('Nette\Bridges\ApplicationLatte\Template', 'getParameters', $arrayType),
+        new AddReturnTypeDeclaration('Nette\Bridges\ApplicationLatte\Template', '__set', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Bridges\ApplicationLatte\Template', '__unset', new VoidType()),
+        new AddReturnTypeDeclaration(
+            'Nette\Bridges\ApplicationLatte\TemplateFactory',
+            'createTemplate',
+            new ObjectType('Nette\Application\UI\ITemplate')
+        ),
+        new AddReturnTypeDeclaration('Nette\Bridges\ApplicationLatte\UIMacros', 'initialize', new VoidType()),
+        new AddReturnTypeDeclaration(
+            'Nette\Bridges\ApplicationTracy\RoutingPanel',
+            'initializePanel',
+            new VoidType()
+        ),
+        new AddReturnTypeDeclaration('Nette\Bridges\ApplicationTracy\RoutingPanel', 'getTab', new StringType()),
+        new AddReturnTypeDeclaration('Nette\Bridges\ApplicationTracy\RoutingPanel', 'getPanel', new StringType()),
+        new AddReturnTypeDeclaration('Nette\Bridges\ApplicationLatte\UIRuntime', 'initialize', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\ComponentReflection', 'getPersistentParams', $arrayType),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\UI\ComponentReflection',
+            'getPersistentComponents',
+            $arrayType
+        ),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\UI\ComponentReflection',
+            'hasCallableMethod',
+            new BooleanType()
+        ),
+        new AddReturnTypeDeclaration('Nette\Application\UI\ComponentReflection', 'combineArgs', $arrayType),
+        new AddReturnTypeDeclaration('Nette\Application\UI\ComponentReflection', 'convertType', new BooleanType()),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\UI\ComponentReflection',
+            'parseAnnotation',
+            new UnionType([$arrayType, new NullType()])
+        ),
+        new AddReturnTypeDeclaration('Nette\Application\UI\ComponentReflection', 'getParameterType', $arrayType),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\UI\ComponentReflection',
+            'hasAnnotation',
+            new BooleanType()
+        ),
+        new AddReturnTypeDeclaration('Nette\Application\UI\ComponentReflection', 'getMethods', $arrayType),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\UI\Control',
+            'getTemplate',
+            new ObjectType('Nette\Application\UI\ITemplate')
+        ),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\UI\Control',
+            'createTemplate',
+            new ObjectType('Nette\Application\UI\ITemplate')
+        ),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Control', 'templatePrepareFilters', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Control', 'flashMessage', new ObjectType('stdClass')),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Control', 'redrawControl', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Control', 'isControlInvalid', new BooleanType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Control', 'getSnippetId', new StringType()),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\UI\Form',
+            'getPresenter',
+            new UnionType([new ObjectType('Nette\Application\UI\Presenter'), new NullType()])
+        ),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Form', 'signalReceived', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\IRenderable', 'redrawControl', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\IRenderable', 'isControlInvalid', new BooleanType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\ITemplate', 'render', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\ITemplate', 'getFile', new UnionType([
+            new StringType(),
+            new NullType(),
+        ])),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\UI\ITemplateFactory',
+            'createTemplate',
+            new ObjectType('Nette\Application\UI\ITemplate')
+        ),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Link', 'getDestination', new StringType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Link', 'getParameters', $arrayType),
+        new AddReturnTypeDeclaration('Nette\Application\UI\Link', '__toString', new StringType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\MethodReflection', 'hasAnnotation', new BooleanType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\IStatePersistent', 'loadState', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\IStatePersistent', 'saveState', new VoidType()),
+        new AddReturnTypeDeclaration('Nette\Application\UI\ISignalReceiver', 'signalReceived', new VoidType()),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\Routers\SimpleRouter',
+            'match',
+            new UnionType([new ObjectType('Nette\Application\Request'), new NullType()])
+        ),
+        new AddReturnTypeDeclaration('Nette\Application\Routers\SimpleRouter', 'getDefaults', $arrayType),
+        new AddReturnTypeDeclaration('Nette\Application\Routers\SimpleRouter', 'getFlags', new IntegerType()),
+        new AddReturnTypeDeclaration('Nette\Application\LinkGenerator', 'link', new StringType()),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\MicroPresenter',
+            'getContext',
+            new UnionType([new ObjectType('Nette\DI\Container'), new NullType()])
+        ),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\MicroPresenter',
+            'createTemplate',
+            new ObjectType('Nette\Application\UI\ITemplate')
+        ),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\MicroPresenter',
+            'redirectUrl',
+            new ObjectType('Nette\Application\Responses\RedirectResponse')
+        ),
+        new AddReturnTypeDeclaration('Nette\Application\MicroPresenter', 'error', new VoidType()),
+        new AddReturnTypeDeclaration(
+            'Nette\Application\MicroPresenter',
+            'getRequest',
+            new UnionType([new ObjectType('Nette\Application\Request'), new NullType()])
+        ),
+    ]);
+};

--- a/config/sets/nette-31.php
+++ b/config/sets/nette-31.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPStan\Type\NullType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\UnionType;
+use Rector\Composer\Rector\ChangePackageVersionComposerRector;
+use Rector\Composer\Rector\RemovePackageComposerRector;
+use Rector\Composer\ValueObject\PackageAndVersion;
+use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+use Rector\Renaming\Rector\StaticCall\RenameStaticMethodRector;
+use Rector\Renaming\ValueObject\MethodCallRename;
+use Rector\Renaming\ValueObject\RenameStaticMethod;
+use Rector\Transform\Rector\Assign\DimFetchAssignToMethodCallRector;
+use Rector\Transform\Rector\Assign\PropertyFetchToMethodCallRector;
+use Rector\Transform\ValueObject\DimFetchAssignToMethodCall;
+use Rector\Transform\ValueObject\PropertyFetchToMethodCall;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddParamTypeDeclarationRector;
+use Rector\TypeDeclaration\ValueObject\AddParamTypeDeclaration;
+use RectorNette\Rector\MethodCall\ContextGetByTypeToConstructorInjectionRector;
+use RectorNette\Set\NetteSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    // forms 3.1
+    $rectorConfig->ruleWithConfiguration(PropertyFetchToMethodCallRector::class, [
+        new PropertyFetchToMethodCall('Nette\Application\UI\Form', 'values', 'getValues'),
+    ]);
+
+    // some attributes were added in nette 3.0, but only in one of latest patch versions; it's is safer to add them in 3.1
+    $rectorConfig->sets([NetteSetList::ANNOTATIONS_TO_ATTRIBUTES]);
+
+    $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
+        'Nette\Bridges\ApplicationLatte\Template' => 'Nette\Bridges\ApplicationLatte\DefaultTemplate',
+
+        // https://github.com/nette/application/compare/v3.0.7...v3.1.0
+        'Nette\Application\IRouter' => 'Nette\Routing\Router',
+        'Nette\Application\IResponse' => 'Nette\Application\Response',
+        'Nette\Application\UI\IRenderable' => 'Nette\Application\UI\Renderable',
+        'Nette\Application\UI\ISignalReceiver' => 'Nette\Application\UI\SignalReceiver',
+        'Nette\Application\UI\IStatePersistent' => 'Nette\Application\UI\StatePersistent',
+        'Nette\Application\UI\ITemplate' => 'Nette\Application\UI\Template',
+        'Nette\Application\UI\ITemplateFactory' => 'Nette\Application\UI\TemplateFactory',
+        'Nette\Bridges\ApplicationLatte\ILatteFactory' => 'Nette\Bridges\ApplicationLatte\LatteFactory',
+
+        // https://github.com/nette/bootstrap/compare/v3.0.2...v3.1.0
+        'Nette\Configurator' => 'Nette\Bootstrap\Configurator',
+
+        // https://github.com/nette/caching/compare/v3.0.2...v3.1.0
+        'Nette\Caching\IBulkReader' => 'Nette\Caching\BulkReader',
+        'Nette\Caching\IStorage' => 'Nette\Caching\Storage',
+        'Nette\Caching\Storages\IJournal' => 'Nette\Caching\Storages\Journal',
+
+        // https://github.com/nette/database/compare/v3.0.7...v3.1.1
+        'Nette\Database\ISupplementalDriver' => 'Nette\Database\Driver',
+        'Nette\Database\IConventions' => 'Nette\Database\Conventions',
+        'Nette\Database\Context' => 'Nette\Database\Explorer',
+        'Nette\Database\IRow' => 'Nette\Database\Row',
+        'Nette\Database\IRowContainer' => 'Nette\Database\ResultSet',
+        'Nette\Database\Table\IRow' => 'Nette\Database\Table\ActiveRow',
+        'Nette\Database\Table\IRowContainer' => 'Nette\Database\Table\Selection',
+
+        // https://github.com/nette/forms/compare/v3.0.7...v3.1.0-RC2
+        'Nette\Forms\IControl' => 'Nette\Forms\Control',
+        'Nette\Forms\IFormRenderer' => 'Nette\Forms\FormRenderer',
+        'Nette\Forms\ISubmitterControl' => 'Nette\Forms\SubmitterControl',
+
+        // https://github.com/nette/mail/compare/v3.0.1...v3.1.5
+        'Nette\Mail\IMailer' => 'Nette\Mail\Mailer',
+
+        // https://github.com/nette/security/compare/v3.0.5...v3.1.2
+        'Nette\Security\IAuthorizator' => 'Nette\Security\Authorizator',
+        'Nette\Security\Identity' => 'Nette\Security\SimpleIdentity',
+        'Nette\Security\IResource' => 'Nette\Security\Resource',
+        'Nette\Security\IRole' => 'Nette\Security\Role',
+
+        // https://github.com/nette/utils/compare/v3.1.4...v3.2.1
+        'Nette\Utils\IHtmlString' => 'Nette\HtmlStringable',
+        'Nette\Localization\ITranslator' => 'Nette\Localization\Translator',
+
+        // https://github.com/nette/latte/compare/v2.5.5...v2.9.2
+        'Latte\ILoader' => 'Latte\Loader',
+        'Latte\IMacro' => 'Latte\Macro',
+        'Latte\Runtime\IHtmlString' => 'Latte\Runtime\HtmlStringable',
+        'Latte\Runtime\ISnippetBridge' => 'Latte\Runtime\SnippetBridge',
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(RenameMethodRector::class, [
+        // https://github.com/nette/caching/commit/60281abf366c4ab76e9436dc1bfe2e402db18b67
+        new MethodCallRename('Nette\Caching\Cache', 'start', 'capture'),
+        // https://github.com/nette/forms/commit/faaaf8b8fd3408a274a9de7ca3f342091010ad5d
+        new MethodCallRename('Nette\Forms\Container', 'addImage', 'addImageButton'),
+        // https://github.com/nette/utils/commit/d0427c1811462dbb6c503143eabe5478b26685f7
+        new MethodCallRename('Nette\Utils\Arrays', 'searchKey', 'getKeyOffset'),
+        new MethodCallRename('Nette\Configurator', 'addParameters', 'addStaticParameters'),
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(RenameStaticMethodRector::class, [
+        // https://github.com/nette/utils/commit/8a4b795acd00f3f6754c28a73a7e776b60350c34
+        new RenameStaticMethod('Nette\Utils\Callback', 'closure', 'Closure', 'fromCallable'),
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(DimFetchAssignToMethodCallRector::class, [
+        new DimFetchAssignToMethodCall(
+            'Nette\Application\Routers\RouteList',
+            'Nette\Application\Routers\Route',
+            'addRoute'
+        ),
+    ]);
+
+    $nullableTemplateType = new UnionType([new ObjectType('Nette\Application\UI\Template'), new NullType()]);
+    $rectorConfig->ruleWithConfiguration(AddParamTypeDeclarationRector::class, [
+        new AddParamTypeDeclaration('Nette\Application\UI\Presenter', 'sendTemplate', 0, $nullableTemplateType),
+    ]);
+
+    $rectorConfig->rule(ContextGetByTypeToConstructorInjectionRector::class);
+
+    $rectorConfig->ruleWithConfiguration(ChangePackageVersionComposerRector::class, [
+        // meta package
+        new PackageAndVersion('nette/nette', '^3.1'),
+        // https://github.com/nette/nette/blob/v3.0.0/composer.json vs https://github.com/nette/nette/blob/v3.1.0/composer.json
+        new PackageAndVersion('nette/application', '^3.1'),
+        new PackageAndVersion('nette/bootstrap', '^3.1'),
+        new PackageAndVersion('nette/caching', '^3.1'),
+        new PackageAndVersion('nette/database', '^3.1'),
+        new PackageAndVersion('nette/di', '^3.0'),
+        new PackageAndVersion('nette/finder', '^2.5'),
+        new PackageAndVersion('nette/forms', '^3.1'),
+        new PackageAndVersion('nette/http', '^3.1'),
+        new PackageAndVersion('nette/mail', '^3.1'),
+        new PackageAndVersion('nette/php-generator', '^3.5'),
+        new PackageAndVersion('nette/robot-loader', '^3.3'),
+        new PackageAndVersion('nette/safe-stream', '^2.4'),
+        new PackageAndVersion('nette/security', '^3.1'),
+        new PackageAndVersion('nette/tokenizer', '^3.0'),
+        new PackageAndVersion('nette/utils', '^3.2'),
+        new PackageAndVersion('latte/latte', '^2.9'),
+        new PackageAndVersion('tracy/tracy', '^2.8'),
+
+        // contributte
+        new PackageAndVersion('contributte/console', '^0.9'),
+        new PackageAndVersion('contributte/event-dispatcher', '^0.8'),
+        new PackageAndVersion('contributte/event-dispatcher-extra', '^0.8'),
+
+        // nettrine
+        new PackageAndVersion('nettrine/annotations', '^0.7'),
+        new PackageAndVersion('nettrine/cache', '^0.3'),
+    ]);
+
+    $rectorConfig->ruleWithConfiguration(RemovePackageComposerRector::class, [
+        'nette/component-model', 'nette/neon',
+    ]);
+};

--- a/config/sets/nette-code-quality.php
+++ b/config/sets/nette-code-quality.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Transform\Rector\FuncCall\FuncCallToStaticCallRector;
+use Rector\Transform\ValueObject\FuncCallToStaticCall;
+use RectorNette\Rector\ClassMethod\TemplateMagicAssignToExplicitVariableArrayRector;
+use RectorNette\Rector\FuncCall\JsonDecodeEncodeToNetteUtilsJsonDecodeEncodeRector;
+use RectorNette\Rector\FuncCall\PregFunctionToNetteUtilsStringsRector;
+use RectorNette\Rector\FuncCall\PregMatchFunctionToNetteUtilsStringsRector;
+use RectorNette\Rector\FuncCall\SubstrStrlenFunctionToNetteUtilsStringsRector;
+use RectorNette\Rector\LNumber\ReplaceTimeNumberWithDateTimeConstantRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(TemplateMagicAssignToExplicitVariableArrayRector::class);
+
+    $rectorConfig->ruleWithConfiguration(FuncCallToStaticCallRector::class, [
+        new FuncCallToStaticCall('file_get_contents', 'Nette\Utils\FileSystem', 'read'),
+        new FuncCallToStaticCall('unlink', 'Nette\Utils\FileSystem', 'delete'),
+        new FuncCallToStaticCall('rmdir', 'Nette\Utils\FileSystem', 'delete'),
+    ]);
+
+    $rectorConfig->rule(SubstrStrlenFunctionToNetteUtilsStringsRector::class);
+    $rectorConfig->rule(PregMatchFunctionToNetteUtilsStringsRector::class);
+    $rectorConfig->rule(PregFunctionToNetteUtilsStringsRector::class);
+    $rectorConfig->rule(JsonDecodeEncodeToNetteUtilsJsonDecodeEncodeRector::class);
+    $rectorConfig->rule(ReplaceTimeNumberWithDateTimeConstantRector::class);
+};

--- a/config/sets/nette-remove-inject.php
+++ b/config/sets/nette-remove-inject.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use RectorNette\Rector\Property\NetteInjectToConstructorInjectionRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(NetteInjectToConstructorInjectionRector::class);
+};

--- a/config/sets/nette/annotations-to-attributes.php
+++ b/config/sets/nette/annotations-to-attributes.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
+use Rector\Php80\ValueObject\AnnotationToAttribute;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->ruleWithConfiguration(AnnotationToAttributeRector::class, [
+        // nette 3.0+, see https://github.com/nette/application/commit/d2471134ed909210de8a3e8559931902b1bee67b#diff-457507a8bdc046dd4f3a4aa1ca51794543fbb1e06f03825ab69ee864549a570c
+        new AnnotationToAttribute('inject', 'Nette\DI\Attributes\Inject'),
+        new AnnotationToAttribute('persistent', 'Nette\Application\Attributes\Persistent'),
+        new AnnotationToAttribute('crossOrigin', 'Nette\Application\Attributes\CrossOrigin'),
+    ]);
+};

--- a/src/Application/FileProcessor/ComposerFileProcessor.php
+++ b/src/Application/FileProcessor/ComposerFileProcessor.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorComposer\Application\FileProcessor;
+
+use Rector\ChangesReporting\ValueObjectFactory\FileDiffFactory;
+use RectorComposer\Contract\Rector\ComposerRectorInterface;
+use Rector\Core\Contract\Processor\FileProcessorInterface;
+use Rector\Core\ValueObject\Application\File;
+use Rector\Core\ValueObject\Configuration;
+use Rector\Core\ValueObject\Error\SystemError;
+use Rector\Core\ValueObject\Reporting\FileDiff;
+use Rector\Parallel\ValueObject\Bridge;
+use Rector\Testing\PHPUnit\StaticPHPUnitEnvironment;
+use Symplify\ComposerJsonManipulator\ComposerJsonFactory;
+use Symplify\ComposerJsonManipulator\Printer\ComposerJsonPrinter;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class ComposerFileProcessor implements FileProcessorInterface
+{
+    /**
+     * @param ComposerRectorInterface[] $composerRectors
+     */
+    public function __construct(
+        private readonly ComposerJsonFactory $composerJsonFactory,
+        private readonly ComposerJsonPrinter $composerJsonPrinter,
+        private readonly FileDiffFactory $fileDiffFactory,
+        private readonly array $composerRectors
+    ) {
+    }
+
+    /**
+     * @return array{system_errors: SystemError[], file_diffs: FileDiff[]}
+     */
+    public function process(File $file, Configuration $configuration): array
+    {
+        $systemErrorsAndFileDiffs = [
+            Bridge::SYSTEM_ERRORS => [],
+            Bridge::FILE_DIFFS => [],
+        ];
+
+        if ($this->composerRectors === []) {
+            return $systemErrorsAndFileDiffs;
+        }
+
+        // to avoid modification of file
+        $smartFileInfo = new SmartFileInfo($file->getFilePath());
+        $oldFileContents = $smartFileInfo->getContents();
+        $composerJson = $this->composerJsonFactory->createFromFileInfo($smartFileInfo);
+
+        $oldComposerJson = clone $composerJson;
+        foreach ($this->composerRectors as $composerRector) {
+            $composerRector->refactor($composerJson);
+        }
+
+        // nothing has changed
+        if ($oldComposerJson->getJsonArray() === $composerJson->getJsonArray()) {
+            return $systemErrorsAndFileDiffs;
+        }
+
+        $changedFileContent = $this->composerJsonPrinter->printToString($composerJson);
+        $file->changeFileContent($changedFileContent);
+
+        $fileDiff = $this->fileDiffFactory->createFileDiff($file, $oldFileContents, $changedFileContent);
+
+        $systemErrorsAndFileDiffs[Bridge::FILE_DIFFS] = [$fileDiff];
+
+        return $systemErrorsAndFileDiffs;
+    }
+
+    public function supports(File $file, Configuration $configuration): bool
+    {
+        $smartFileInfo = new SmartFileInfo($file->getFilePath());
+
+        if ($this->isJsonInTests($smartFileInfo)) {
+            return true;
+        }
+
+        return $smartFileInfo->getBasename() === 'composer.json';
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getSupportedFileExtensions(): array
+    {
+        return ['json'];
+    }
+
+    private function isJsonInTests(SmartFileInfo $fileInfo): bool
+    {
+        if (! StaticPHPUnitEnvironment::isPHPUnitRun()) {
+            return false;
+        }
+
+        return $fileInfo->hasSuffixes(['json']);
+    }
+}

--- a/src/Composer/ComposerJsonFactory.php
+++ b/src/Composer/ComposerJsonFactory.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorComposer\Composer;
+
+use Symplify\ComposerJsonManipulator\ValueObject\ComposerJson;
+use Symplify\ComposerJsonManipulator\ValueObject\ComposerJsonSection;
+
+class ComposerJsonFactory
+{
+    public static function createFromFilePath(string $filePath): ComposerJson
+    {
+        $content = file_get_contents($filePath) ?: '';
+        return self::createFromContent($content);
+    }
+
+    public static function createFromContent(string $content): ComposerJson
+    {
+        return self::createFromArray(json_decode($content, true));
+    }
+
+    public static function createFromArray(array $jsonArray): ComposerJson
+    {
+        $composerJson = new ComposerJson();
+
+        if (isset($jsonArray[ComposerJsonSection::CONFIG])) {
+            $composerJson->setConfig($jsonArray[ComposerJsonSection::CONFIG]);
+        }
+
+        if (isset($jsonArray[ComposerJsonSection::NAME])) {
+            $composerJson->setName($jsonArray[ComposerJsonSection::NAME]);
+        }
+
+        if (isset($jsonArray[ComposerJsonSection::TYPE])) {
+            $composerJson->setType($jsonArray[ComposerJsonSection::TYPE]);
+        }
+
+        if (isset($jsonArray[ComposerJsonSection::AUTHORS])) {
+            $composerJson->setAuthors($jsonArray[ComposerJsonSection::AUTHORS]);
+        }
+
+        if (isset($jsonArray[ComposerJsonSection::DESCRIPTION])) {
+            $composerJson->setDescription($jsonArray[ComposerJsonSection::DESCRIPTION]);
+        }
+
+        if (isset($jsonArray[ComposerJsonSection::KEYWORDS])) {
+            $composerJson->setKeywords($jsonArray[ComposerJsonSection::KEYWORDS]);
+        }
+
+        if (isset($jsonArray[ComposerJsonSection::HOMEPAGE])) {
+            $composerJson->setHomepage($jsonArray[ComposerJsonSection::HOMEPAGE]);
+        }
+
+        if (isset($jsonArray[ComposerJsonSection::LICENSE])) {
+            $composerJson->setLicense($jsonArray[ComposerJsonSection::LICENSE]);
+        }
+
+        if (isset($jsonArray[ComposerJsonSection::BIN])) {
+            $composerJson->setBin($jsonArray[ComposerJsonSection::BIN]);
+        }
+
+        if (isset($jsonArray[ComposerJsonSection::REQUIRE])) {
+            $composerJson->setRequire($jsonArray[ComposerJsonSection::REQUIRE]);
+        }
+
+        if (isset($jsonArray[ComposerJsonSection::REQUIRE_DEV])) {
+            $composerJson->setRequireDev($jsonArray[ComposerJsonSection::REQUIRE_DEV]);
+        }
+
+        if (isset($jsonArray[ComposerJsonSection::AUTOLOAD])) {
+            $composerJson->setAutoload($jsonArray[ComposerJsonSection::AUTOLOAD]);
+        }
+
+        if (isset($jsonArray[ComposerJsonSection::AUTOLOAD_DEV])) {
+            $composerJson->setAutoloadDev($jsonArray[ComposerJsonSection::AUTOLOAD_DEV]);
+        }
+
+        if (isset($jsonArray[ComposerJsonSection::REPLACE])) {
+            $composerJson->setReplace($jsonArray[ComposerJsonSection::REPLACE]);
+        }
+
+        if (isset($jsonArray[ComposerJsonSection::EXTRA])) {
+            $composerJson->setExtra($jsonArray[ComposerJsonSection::EXTRA]);
+        }
+
+        if (isset($jsonArray[ComposerJsonSection::SCRIPTS])) {
+            $composerJson->setScripts($jsonArray[ComposerJsonSection::SCRIPTS]);
+        }
+
+        if (isset($jsonArray[ComposerJsonSection::SCRIPTS_DESCRIPTIONS])) {
+            $composerJson->setScriptsDescriptions($jsonArray[ComposerJsonSection::SCRIPTS_DESCRIPTIONS]);
+        }
+
+        if (isset($jsonArray[ComposerJsonSection::SUGGEST])) {
+            $composerJson->setSuggest($jsonArray[ComposerJsonSection::SUGGEST]);
+        }
+
+        if (isset($jsonArray[ComposerJsonSection::MINIMUM_STABILITY])) {
+            $composerJson->setMinimumStability($jsonArray[ComposerJsonSection::MINIMUM_STABILITY]);
+        }
+
+        if (isset($jsonArray[ComposerJsonSection::PREFER_STABLE])) {
+            $composerJson->setPreferStable($jsonArray[ComposerJsonSection::PREFER_STABLE]);
+        }
+
+        if (isset($jsonArray[ComposerJsonSection::CONFLICT])) {
+            $composerJson->setConflicts($jsonArray[ComposerJsonSection::CONFLICT]);
+        }
+
+        if (isset($jsonArray[ComposerJsonSection::REPOSITORIES])) {
+            $composerJson->setRepositories($jsonArray[ComposerJsonSection::REPOSITORIES]);
+        }
+
+        if (isset($jsonArray[ComposerJsonSection::VERSION])) {
+            $composerJson->setVersion($jsonArray[ComposerJsonSection::VERSION]);
+        }
+
+        if (isset($jsonArray[ComposerJsonSection::PROVIDE])) {
+            $composerJson->setProvide($jsonArray[ComposerJsonSection::PROVIDE]);
+        }
+
+        $orderedKeys = array_keys($jsonArray);
+        $composerJson->setOrderedKeys($orderedKeys);
+
+        return $composerJson;
+    }
+}

--- a/src/Contract/Rector/ComposerRectorInterface.php
+++ b/src/Contract/Rector/ComposerRectorInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorComposer\Contract\Rector;
+
+use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Core\Contract\Rector\RectorInterface;
+use Symplify\ComposerJsonManipulator\ValueObject\ComposerJson;
+
+interface ComposerRectorInterface extends RectorInterface, ConfigurableRectorInterface
+{
+    public function refactor(ComposerJson $composerJson): void;
+}

--- a/src/Contract/VersionAwareInterface.php
+++ b/src/Contract/VersionAwareInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorComposer\Contract;
+
+interface VersionAwareInterface
+{
+    public function getVersion(): string;
+}

--- a/src/Guard/VersionGuard.php
+++ b/src/Guard/VersionGuard.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorComposer\Guard;
+
+use Composer\Semver\VersionParser;
+use RectorComposer\Contract\VersionAwareInterface;
+
+final class VersionGuard
+{
+    public function __construct(
+        private readonly VersionParser $versionParser
+    ) {
+    }
+
+    /**
+     * @param VersionAwareInterface[] $versionAwares
+     */
+    public function validate(array $versionAwares): void
+    {
+        foreach ($versionAwares as $versionAware) {
+            $this->versionParser->parseConstraints($versionAware->getVersion());
+        }
+    }
+}

--- a/src/Rector/AddPackageToRequireComposerRector.php
+++ b/src/Rector/AddPackageToRequireComposerRector.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorComposer\Rector;
+
+use RectorComposer\Contract\Rector\ComposerRectorInterface;
+use RectorComposer\Guard\VersionGuard;
+use RectorComposer\ValueObject\PackageAndVersion;
+use Symplify\ComposerJsonManipulator\ValueObject\ComposerJson;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+/**
+ * @see \RectorComposer\Tests\Rector\AddPackageToRequireComposerRector\AddPackageToRequireComposerRectorTest
+ */
+final class AddPackageToRequireComposerRector implements ComposerRectorInterface
+{
+    /**
+     * @var PackageAndVersion[]
+     */
+    private array $packagesAndVersions = [];
+
+    public function __construct(
+        private readonly VersionGuard $versionGuard
+    ) {
+    }
+
+    public function refactor(ComposerJson $composerJson): void
+    {
+        foreach ($this->packagesAndVersions as $packageAndVersion) {
+            $composerJson->addRequiredPackage($packageAndVersion->getPackageName(), $packageAndVersion->getVersion());
+        }
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Add package to "require" in `composer.json`', [new ConfiguredCodeSample(
+            <<<'CODE_SAMPLE'
+{
+}
+CODE_SAMPLE
+            ,
+            <<<'CODE_SAMPLE'
+{
+    "require": {
+        "symfony/console": "^3.4"
+    }
+}
+CODE_SAMPLE
+            ,
+            [new PackageAndVersion('symfony/console', '^3.4')]
+        ),
+        ]);
+    }
+
+    /**
+     * @param mixed[] $configuration
+     */
+    public function configure(array $configuration): void
+    {
+        Assert::allIsAOf($configuration, PackageAndVersion::class);
+
+        $this->versionGuard->validate($configuration);
+        $this->packagesAndVersions = $configuration;
+    }
+}

--- a/src/Rector/AddPackageToRequireDevComposerRector.php
+++ b/src/Rector/AddPackageToRequireDevComposerRector.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorComposer\Rector;
+
+use RectorComposer\Contract\Rector\ComposerRectorInterface;
+use RectorComposer\Guard\VersionGuard;
+use RectorComposer\ValueObject\PackageAndVersion;
+use Symplify\ComposerJsonManipulator\ValueObject\ComposerJson;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+/**
+ * @see \RectorComposer\Tests\Rector\AddPackageToRequireDevComposerRector\AddPackageToRequireDevComposerRectorTest
+ */
+final class AddPackageToRequireDevComposerRector implements ComposerRectorInterface
+{
+    /**
+     * @var PackageAndVersion[]
+     */
+    private array $packageAndVersions = [];
+
+    public function __construct(
+        private readonly VersionGuard $versionGuard
+    ) {
+    }
+
+    public function refactor(ComposerJson $composerJson): void
+    {
+        foreach ($this->packageAndVersions as $packageAndVersion) {
+            $composerJson->addRequiredDevPackage(
+                $packageAndVersion->getPackageName(),
+                $packageAndVersion->getVersion()
+            );
+        }
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Add package to "require-dev" in `composer.json`', [new ConfiguredCodeSample(
+            <<<'CODE_SAMPLE'
+{
+}
+CODE_SAMPLE
+            ,
+            <<<'CODE_SAMPLE'
+{
+    "require-dev": {
+        "symfony/console": "^3.4"
+    }
+}
+CODE_SAMPLE
+            ,
+            [new PackageAndVersion('symfony/console', '^3.4')]
+        ),
+        ]);
+    }
+
+    /**
+     * @param mixed[] $configuration
+     */
+    public function configure(array $configuration): void
+    {
+        Assert::allIsAOf($configuration, PackageAndVersion::class);
+
+        $this->versionGuard->validate($configuration);
+        $this->packageAndVersions = $configuration;
+    }
+}

--- a/src/Rector/ChangePackageVersionComposerRector.php
+++ b/src/Rector/ChangePackageVersionComposerRector.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorComposer\Rector;
+
+use RectorComposer\Contract\Rector\ComposerRectorInterface;
+use RectorComposer\Guard\VersionGuard;
+use RectorComposer\ValueObject\PackageAndVersion;
+use Symplify\ComposerJsonManipulator\ValueObject\ComposerJson;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+/**
+ * @see \RectorComposer\Tests\Rector\ChangePackageVersionComposerRector\ChangePackageVersionComposerRectorTest
+ */
+final class ChangePackageVersionComposerRector implements ComposerRectorInterface
+{
+    /**
+     * @var PackageAndVersion[]
+     */
+    private array $packagesAndVersions = [];
+
+    public function __construct(
+        private readonly VersionGuard $versionGuard
+    ) {
+    }
+
+    public function refactor(ComposerJson $composerJson): void
+    {
+        foreach ($this->packagesAndVersions as $packageAndVersion) {
+            $composerJson->changePackageVersion(
+                $packageAndVersion->getPackageName(),
+                $packageAndVersion->getVersion()
+            );
+        }
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Change package version `composer.json`', [new ConfiguredCodeSample(
+            <<<'CODE_SAMPLE'
+{
+    "require": {
+        "symfony/console": "^3.4"
+    }
+}
+CODE_SAMPLE
+            ,
+            <<<'CODE_SAMPLE'
+{
+    "require": {
+        "symfony/console": "^4.4"
+    }
+}
+CODE_SAMPLE
+            ,
+            [new PackageAndVersion('symfony/console', '^4.4')]
+        ),
+        ]);
+    }
+
+    /**
+     * @param mixed[] $configuration
+     */
+    public function configure(array $configuration): void
+    {
+        Assert::allIsAOf($configuration, PackageAndVersion::class);
+
+        $this->versionGuard->validate($configuration);
+        $this->packagesAndVersions = $configuration;
+    }
+}

--- a/src/Rector/RemovePackageComposerRector.php
+++ b/src/Rector/RemovePackageComposerRector.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorComposer\Rector;
+
+use RectorComposer\Contract\Rector\ComposerRectorInterface;
+use Symplify\ComposerJsonManipulator\ValueObject\ComposerJson;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+/**
+ * @see \RectorComposer\Tests\Rector\RemovePackageComposerRector\RemovePackageComposerRectorTest
+ */
+final class RemovePackageComposerRector implements ComposerRectorInterface
+{
+    /**
+     * @var string[]
+     */
+    private array $packageNames = [];
+
+    public function refactor(ComposerJson $composerJson): void
+    {
+        foreach ($this->packageNames as $packageName) {
+            $composerJson->removePackage($packageName);
+        }
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Remove package from "require" and "require-dev" in `composer.json`', [
+            new ConfiguredCodeSample(
+                <<<'CODE_SAMPLE'
+{
+    "require": {
+        "symfony/console": "^3.4"
+    }
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+{
+}
+CODE_SAMPLE
+                ,
+                ['symfony/console']
+            ),
+        ]);
+    }
+
+    /**
+     * @param mixed[] $configuration
+     */
+    public function configure(array $configuration): void
+    {
+        Assert::allString($configuration);
+
+        $this->packageNames = $configuration;
+    }
+}

--- a/src/Rector/RenamePackageComposerRector.php
+++ b/src/Rector/RenamePackageComposerRector.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorComposer\Rector;
+
+use RectorComposer\Contract\Rector\ComposerRectorInterface;
+use RectorComposer\ValueObject\RenamePackage;
+use Symplify\ComposerJsonManipulator\ValueObject\ComposerJson;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+/**
+ * @see \RectorComposer\Tests\Rector\RenamePackageComposerRector\RenamePackageComposerRectorTest
+ */
+final class RenamePackageComposerRector implements ComposerRectorInterface
+{
+    /**
+     * @var RenamePackage[]
+     */
+    private array $renamePackages = [];
+
+    public function refactor(ComposerJson $composerJson): void
+    {
+        foreach ($this->renamePackages as $renamePackage) {
+            if ($composerJson->hasRequiredPackage($renamePackage->getOldPackageName())) {
+                $version = $composerJson->getRequire()[$renamePackage->getOldPackageName()];
+                $composerJson->replacePackage(
+                    $renamePackage->getOldPackageName(),
+                    $renamePackage->getNewPackageName(),
+                    $version
+                );
+            }
+
+            if ($composerJson->hasRequiredDevPackage($renamePackage->getOldPackageName())) {
+                $version = $composerJson->getRequireDev()[$renamePackage->getOldPackageName()];
+                $composerJson->replacePackage(
+                    $renamePackage->getOldPackageName(),
+                    $renamePackage->getNewPackageName(),
+                    $version
+                );
+            }
+        }
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Change package name in `composer.json`', [new ConfiguredCodeSample(
+            <<<'CODE_SAMPLE'
+{
+    "require": {
+        "rector/rector": "dev-main"
+    }
+}
+CODE_SAMPLE
+            ,
+            <<<'CODE_SAMPLE'
+{
+    "require": {
+        "rector/rector-src": "dev-main"
+    }
+}
+CODE_SAMPLE
+            ,
+            [new RenamePackage('rector/rector', 'rector/rector-src')]
+        ),
+        ]);
+    }
+
+    /**
+     * @param mixed[] $configuration
+     */
+    public function configure(array $configuration): void
+    {
+        Assert::allIsAOf($configuration, RenamePackage::class);
+        $this->renamePackages = $configuration;
+    }
+}

--- a/src/Rector/ReplacePackageAndVersionComposerRector.php
+++ b/src/Rector/ReplacePackageAndVersionComposerRector.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorComposer\Rector;
+
+use RectorComposer\Contract\Rector\ComposerRectorInterface;
+use RectorComposer\Guard\VersionGuard;
+use RectorComposer\ValueObject\ReplacePackageAndVersion;
+use Symplify\ComposerJsonManipulator\ValueObject\ComposerJson;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+/**
+ * @see \RectorComposer\Tests\Rector\ReplacePackageAndVersionComposerRector\ReplacePackageAndVersionComposerRectorTest
+ */
+final class ReplacePackageAndVersionComposerRector implements ComposerRectorInterface
+{
+    /**
+     * @var ReplacePackageAndVersion[]
+     */
+    private array $replacePackagesAndVersions = [];
+
+    public function __construct(
+        private readonly VersionGuard $versionGuard
+    ) {
+    }
+
+    public function refactor(ComposerJson $composerJson): void
+    {
+        foreach ($this->replacePackagesAndVersions as $replacePackageAndVersion) {
+            $composerJson->replacePackage(
+                $replacePackageAndVersion->getOldPackageName(),
+                $replacePackageAndVersion->getNewPackageName(),
+                $replacePackageAndVersion->getVersion()
+            );
+        }
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Change package name and version `composer.json`', [new ConfiguredCodeSample(
+            <<<'CODE_SAMPLE'
+{
+    "require-dev": {
+        "symfony/console": "^3.4"
+    }
+}
+CODE_SAMPLE
+            ,
+            <<<'CODE_SAMPLE'
+{
+    "require-dev": {
+        "symfony/http-kernel": "^4.4"
+    }
+}
+CODE_SAMPLE
+            ,
+            [new ReplacePackageAndVersion('symfony/console', 'symfony/http-kernel', '^4.4')]
+        ),
+        ]);
+    }
+
+    /**
+     * @param mixed[] $configuration
+     */
+    public function configure(array $configuration): void
+    {
+        Assert::allIsAOf($configuration, ReplacePackageAndVersion::class);
+
+        $this->versionGuard->validate($configuration);
+        $this->replacePackagesAndVersions = $configuration;
+    }
+}

--- a/src/ValueObject/PackageAndVersion.php
+++ b/src/ValueObject/PackageAndVersion.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorComposer\ValueObject;
+
+use RectorComposer\Contract\VersionAwareInterface;
+
+final class PackageAndVersion implements VersionAwareInterface
+{
+    public function __construct(
+        private readonly string $packageName,
+        private readonly string $version
+    ) {
+    }
+
+    public function getPackageName(): string
+    {
+        return $this->packageName;
+    }
+
+    public function getVersion(): string
+    {
+        return $this->version;
+    }
+}

--- a/src/ValueObject/RenamePackage.php
+++ b/src/ValueObject/RenamePackage.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorComposer\ValueObject;
+
+final class RenamePackage
+{
+    public function __construct(
+        private readonly string $oldPackageName,
+        private readonly string $newPackageName
+    ) {
+    }
+
+    public function getOldPackageName(): string
+    {
+        return $this->oldPackageName;
+    }
+
+    public function getNewPackageName(): string
+    {
+        return $this->newPackageName;
+    }
+}

--- a/src/ValueObject/ReplacePackageAndVersion.php
+++ b/src/ValueObject/ReplacePackageAndVersion.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorComposer\ValueObject;
+
+use RectorComposer\Contract\VersionAwareInterface;
+use RectorComposer\Rector\ChangePackageVersionComposerRector;
+use Webmozart\Assert\Assert;
+
+final class ReplacePackageAndVersion implements VersionAwareInterface
+{
+    private readonly string $oldPackageName;
+
+    private readonly string $newPackageName;
+
+    public function __construct(
+        string $oldPackageName,
+        string $newPackageName,
+        private readonly string $version
+    ) {
+        Assert::notSame(
+            $oldPackageName,
+            $newPackageName,
+            'Old and new package have to be different. If you want to only change package version, use ' . ChangePackageVersionComposerRector::class
+        );
+
+        $this->oldPackageName = $oldPackageName;
+        $this->newPackageName = $newPackageName;
+    }
+
+    public function getOldPackageName(): string
+    {
+        return $this->oldPackageName;
+    }
+
+    public function getNewPackageName(): string
+    {
+        return $this->newPackageName;
+    }
+
+    public function getVersion(): string
+    {
+        return $this->version;
+    }
+}

--- a/tests/Rector/AddPackageToRequireComposerRector/AddPackageToRequireComposerRectorTest.php
+++ b/tests/Rector/AddPackageToRequireComposerRector/AddPackageToRequireComposerRectorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorComposer\Tests\Rector\AddPackageToRequireComposerRector;
+
+use Iterator;
+use Rector\Testing\Fixture\FixtureFileFinder;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AddPackageToRequireComposerRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $file): void
+    {
+        $this->doTestFile($file);
+    }
+
+    public function provideData(): Iterator
+    {
+        return FixtureFileFinder::yieldDirectory(__DIR__ . '/Fixture', '*.json');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/some_config.php';
+    }
+}

--- a/tests/Rector/AddPackageToRequireComposerRector/Fixture/added_package.json
+++ b/tests/Rector/AddPackageToRequireComposerRector/Fixture/added_package.json
@@ -1,0 +1,16 @@
+{
+    "require-dev": {
+        "vendor1/package1": "^1.0",
+        "vendor1/package2": "^2.0"
+    }
+}
+-----
+{
+    "require": {
+        "vendor1/package3": "^3.0"
+    },
+    "require-dev": {
+        "vendor1/package1": "^1.0",
+        "vendor1/package2": "^2.0"
+    }
+}

--- a/tests/Rector/AddPackageToRequireComposerRector/config/some_config.php
+++ b/tests/Rector/AddPackageToRequireComposerRector/config/some_config.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use RectorComposer\Rector\AddPackageToRequireComposerRector;
+use RectorComposer\ValueObject\PackageAndVersion;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void
+{
+    $rectorConfig->import(__DIR__ . '/../../../../config/config.php');
+    $rectorConfig
+        ->ruleWithConfiguration(
+            AddPackageToRequireComposerRector::class,
+            [new PackageAndVersion('vendor1/package3', '^3.0')]
+        );
+};

--- a/tests/Rector/AddPackageToRequireDevComposerRector/AddPackageToRequireDevComposerRectorTest.php
+++ b/tests/Rector/AddPackageToRequireDevComposerRector/AddPackageToRequireDevComposerRectorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorComposer\Tests\Rector\AddPackageToRequireDevComposerRector;
+
+use Iterator;
+use Rector\Testing\Fixture\FixtureFileFinder;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AddPackageToRequireDevComposerRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $file): void
+    {
+        $this->doTestFile($file);
+    }
+
+    public function provideData(): Iterator
+    {
+        return FixtureFileFinder::yieldDirectory(__DIR__ . '/Fixture', '*.json');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/some_config.php';
+    }
+}

--- a/tests/Rector/AddPackageToRequireDevComposerRector/Fixture/missing_package.json
+++ b/tests/Rector/AddPackageToRequireDevComposerRector/Fixture/missing_package.json
@@ -1,0 +1,16 @@
+{
+    "require": {
+        "vendor1/package1": "^1.0",
+        "vendor1/package2": "^2.0"
+    }
+}
+-----
+{
+    "require": {
+        "vendor1/package1": "^1.0",
+        "vendor1/package2": "^2.0"
+    },
+    "require-dev": {
+        "vendor1/package3": "^3.0"
+    }
+}

--- a/tests/Rector/AddPackageToRequireDevComposerRector/Fixture/skip_existing_package.json
+++ b/tests/Rector/AddPackageToRequireDevComposerRector/Fixture/skip_existing_package.json
@@ -1,0 +1,9 @@
+{
+    "require": {
+        "vendor1/package1": "^1.0"
+    },
+    "require-dev": {
+        "vendor1/package2": "^2.0",
+        "vendor1/package3": "^3.0"
+    }
+}

--- a/tests/Rector/AddPackageToRequireDevComposerRector/Fixture/skip_existing_versions.json
+++ b/tests/Rector/AddPackageToRequireDevComposerRector/Fixture/skip_existing_versions.json
@@ -1,0 +1,9 @@
+{
+    "require": {
+        "vendor1/package1": "^1.0",
+        "vendor1/package2": "^2.0"
+    },
+    "require-dev": {
+        "vendor1/package3": "^3.0"
+    }
+}

--- a/tests/Rector/AddPackageToRequireDevComposerRector/config/some_config.php
+++ b/tests/Rector/AddPackageToRequireDevComposerRector/config/some_config.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use RectorComposer\Rector\AddPackageToRequireDevComposerRector;
+use RectorComposer\ValueObject\PackageAndVersion;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void
+{
+    $rectorConfig->import(__DIR__ . '/../../../../config/config.php');
+    $rectorConfig
+        ->ruleWithConfiguration(AddPackageToRequireDevComposerRector::class, [
+            new PackageAndVersion('vendor1/package3', '^3.0'),
+            new PackageAndVersion('vendor1/package1', '^3.0'),
+            new PackageAndVersion('vendor1/package2', '^3.0'),
+        ]);
+};

--- a/tests/Rector/ChangePackageVersionComposerRector/ChangePackageVersionComposerRectorTest.php
+++ b/tests/Rector/ChangePackageVersionComposerRector/ChangePackageVersionComposerRectorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorComposer\Tests\Rector\ChangePackageVersionComposerRector;
+
+use Iterator;
+use Rector\Testing\Fixture\FixtureFileFinder;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ChangePackageVersionComposerRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $file): void
+    {
+        $this->doTestFile($file);
+    }
+
+    public function provideData(): Iterator
+    {
+        return FixtureFileFinder::yieldDirectory(__DIR__ . '/Fixture', '*.json');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/some_config.php';
+    }
+}

--- a/tests/Rector/ChangePackageVersionComposerRector/Fixture/change_package.json
+++ b/tests/Rector/ChangePackageVersionComposerRector/Fixture/change_package.json
@@ -1,0 +1,13 @@
+{
+    "require-dev": {
+        "vendor1/package1": "^1.0",
+        "vendor1/package3": "^2.0"
+    }
+}
+-----
+{
+    "require-dev": {
+        "vendor1/package1": "^1.0",
+        "vendor1/package3": "^15.0"
+    }
+}

--- a/tests/Rector/ChangePackageVersionComposerRector/config/some_config.php
+++ b/tests/Rector/ChangePackageVersionComposerRector/config/some_config.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use RectorComposer\Rector\ChangePackageVersionComposerRector;
+use RectorComposer\ValueObject\PackageAndVersion;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void
+{
+    $rectorConfig->import(__DIR__ . '/../../../../config/config.php');
+    $rectorConfig
+        ->ruleWithConfiguration(
+            ChangePackageVersionComposerRector::class,
+            [new PackageAndVersion('vendor1/package3', '^15.0')]
+        );
+};

--- a/tests/Rector/CombinationComposerRector/CombinationComposerRectorTest.php
+++ b/tests/Rector/CombinationComposerRector/CombinationComposerRectorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorComposer\Tests\Rector\CombinationComposerRector;
+
+use Iterator;
+use Rector\Testing\Fixture\FixtureFileFinder;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class CombinationComposerRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $file): void
+    {
+        $this->doTestFile($file);
+    }
+
+    public function provideData(): Iterator
+    {
+        return FixtureFileFinder::yieldDirectory(__DIR__ . '/Fixture', '*.json');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/some_config.php';
+    }
+}

--- a/tests/Rector/CombinationComposerRector/Fixture/basic_package.json
+++ b/tests/Rector/CombinationComposerRector/Fixture/basic_package.json
@@ -1,0 +1,15 @@
+{
+    "require": {
+        "vendor1/package1": "^1.0",
+        "vendor1/package2": "^2.0",
+        "vendor1/package3": "^3.0"
+    }
+}
+-----
+{
+    "require": {
+        "vendor1/package1": "^1.0",
+        "vendor1/package3": "~3.0.0",
+        "vendor2/package1": "^3.0"
+    }
+}

--- a/tests/Rector/CombinationComposerRector/config/some_config.php
+++ b/tests/Rector/CombinationComposerRector/config/some_config.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use RectorComposer\Rector\ChangePackageVersionComposerRector;
+use RectorComposer\Rector\ReplacePackageAndVersionComposerRector;
+use RectorComposer\ValueObject\PackageAndVersion;
+use RectorComposer\ValueObject\ReplacePackageAndVersion;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void
+{
+    $rectorConfig->import(__DIR__ . '/../../../../config/config.php');
+    $rectorConfig
+        ->ruleWithConfiguration(
+            ReplacePackageAndVersionComposerRector::class,
+            [new ReplacePackageAndVersion('vendor1/package2', 'vendor2/package1', '^3.0')]
+        );
+
+    $rectorConfig
+        ->ruleWithConfiguration(
+            ChangePackageVersionComposerRector::class,
+            [new PackageAndVersion('vendor1/package3', '~3.0.0')]
+        );
+};

--- a/tests/Rector/RemovePackageComposerRector/Fixture/remove_package.json
+++ b/tests/Rector/RemovePackageComposerRector/Fixture/remove_package.json
@@ -1,0 +1,11 @@
+{
+    "require": {
+        "vendor1/package1": "^1.0",
+        "vendor1/package2": "^2.0"
+    },
+    "require-dev": {
+        "vendor1/package3": "^3.0"
+    }
+}
+-----
+[]

--- a/tests/Rector/RemovePackageComposerRector/RemovePackageComposerRectorTest.php
+++ b/tests/Rector/RemovePackageComposerRector/RemovePackageComposerRectorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorComposer\Tests\Rector\RemovePackageComposerRector;
+
+use Iterator;
+use Rector\Testing\Fixture\FixtureFileFinder;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RemovePackageComposerRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $file): void
+    {
+        $this->doTestFile($file);
+    }
+
+    public function provideData(): Iterator
+    {
+        return FixtureFileFinder::yieldDirectory(__DIR__ . '/Fixture', '*.json');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/some_config.php';
+    }
+}

--- a/tests/Rector/RemovePackageComposerRector/config/some_config.php
+++ b/tests/Rector/RemovePackageComposerRector/config/some_config.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use RectorComposer\Rector\RemovePackageComposerRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void
+{
+    $rectorConfig->import(__DIR__ . '/../../../../config/config.php');
+    $rectorConfig
+        ->ruleWithConfiguration(
+            RemovePackageComposerRector::class,
+            ['vendor1/package3', 'vendor1/package1', 'vendor1/package2']
+        );
+};

--- a/tests/Rector/RenamePackageComposerRector/Fixture/remove_package.json
+++ b/tests/Rector/RenamePackageComposerRector/Fixture/remove_package.json
@@ -1,0 +1,17 @@
+{
+    "require": {
+        "foo/bar": "dev-main"
+    },
+    "require-dev": {
+        "foo/baz": "dev-main"
+    }
+}
+-----
+{
+    "require": {
+        "baz/bar": "dev-main"
+    },
+    "require-dev": {
+        "baz/baz": "dev-main"
+    }
+}

--- a/tests/Rector/RenamePackageComposerRector/RenamePackageComposerRectorTest.php
+++ b/tests/Rector/RenamePackageComposerRector/RenamePackageComposerRectorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorComposer\Tests\Rector\RenamePackageComposerRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class RenamePackageComposerRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $file): void
+    {
+        $this->doTestFile($file);
+    }
+
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture', '*.json');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/some_config.php';
+    }
+}

--- a/tests/Rector/RenamePackageComposerRector/config/some_config.php
+++ b/tests/Rector/RenamePackageComposerRector/config/some_config.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use RectorComposer\Rector\RenamePackageComposerRector;
+use RectorComposer\ValueObject\RenamePackage;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void
+{
+    $rectorConfig->import(__DIR__ . '/../../../../config/config.php');
+    $rectorConfig
+        ->ruleWithConfiguration(
+            RenamePackageComposerRector::class,
+            [new RenamePackage('foo/bar', 'baz/bar'), new RenamePackage('foo/baz', 'baz/baz')]
+        );
+};

--- a/tests/Rector/ReplacePackageAndVersionComposerRector/Fixture/moved_package.json
+++ b/tests/Rector/ReplacePackageAndVersionComposerRector/Fixture/moved_package.json
@@ -1,0 +1,11 @@
+{
+    "require": {
+        "vendor1/package1": "^1.0"
+    }
+}
+-----
+{
+    "require": {
+        "vendor1/package3": "^4.0"
+    }
+}

--- a/tests/Rector/ReplacePackageAndVersionComposerRector/Fixture/skip_missing_package.json
+++ b/tests/Rector/ReplacePackageAndVersionComposerRector/Fixture/skip_missing_package.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "vendor1/package4": "^1.0"
+    }
+}

--- a/tests/Rector/ReplacePackageAndVersionComposerRector/ReplacePackageAndVersionComposerRectorTest.php
+++ b/tests/Rector/ReplacePackageAndVersionComposerRector/ReplacePackageAndVersionComposerRectorTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RectorComposer\Tests\Rector\ReplacePackageAndVersionComposerRector;
+
+use Iterator;
+use Rector\Testing\Fixture\FixtureFileFinder;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ReplacePackageAndVersionComposerRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $file): void
+    {
+        $this->doTestFile($file);
+    }
+
+    public function provideData(): Iterator
+    {
+        return FixtureFileFinder::yieldDirectory(__DIR__ . '/Fixture', '*.json');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/some_config.php';
+    }
+}

--- a/tests/Rector/ReplacePackageAndVersionComposerRector/config/some_config.php
+++ b/tests/Rector/ReplacePackageAndVersionComposerRector/config/some_config.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use RectorComposer\Rector\ReplacePackageAndVersionComposerRector;
+use RectorComposer\ValueObject\ReplacePackageAndVersion;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void
+{
+    $rectorConfig->import(__DIR__ . '/../../../../config/config.php');
+    $rectorConfig
+        ->ruleWithConfiguration(
+            ReplacePackageAndVersionComposerRector::class,
+            [new ReplacePackageAndVersion('vendor1/package1', 'vendor1/package3', '^4.0')]
+        );
+};


### PR DESCRIPTION
migrated from rector
only two changes have to be done:
- ComposerJsonFactory was replaced by internal class because of dependency hell
- ComposerJsonPrinter was replaced by json_encode function with flags